### PR TITLE
Keyboard fixes

### DIFF
--- a/app/ui/qml/KeyboardKey.qml
+++ b/app/ui/qml/KeyboardKey.qml
@@ -157,7 +157,7 @@ Item {
 
 		Label {
 			id: label
-			visible: root.text != root.shiftText
+			visible: root.text != root.shiftText.toLowerCase()
 			padding: 5
 			anchors.bottom: parent.bottom
 			text: root.text
@@ -167,7 +167,7 @@ Item {
 			id: shiftLabel
 			padding: 5
 			anchors.top: parent.top
-			text: root.text == root.shiftText ? root.shiftText.toUpperCase() : root.shiftText
+			text: root.shiftText
 		}
 
 		PropertyAnimation {

--- a/app/ui/qml/KeyboardView.qml
+++ b/app/ui/qml/KeyboardView.qml
@@ -148,13 +148,13 @@ ColumnLayout {
 	function pressKey(event) {
 		var key = getKey(event);
 		if(key !== null)
-			getKey(event).pressed = true;
+			key.pressed = true;
 	}
 
 	function releaseKey(event) {
 		var key = getKey(event);
 		if(key !== null)
-			getKey(event).pressed = false;
+			key.pressed = false;
 	}
 
 	function releaseAllKeys() {

--- a/app/ui/qml/KeyboardView.qml
+++ b/app/ui/qml/KeyboardView.qml
@@ -68,7 +68,7 @@ ColumnLayout {
 		return null;
 	}
 
-	function getKey(event) {
+	function getKey(event, normalizeText = false) {
 		if(event["key"] === Qt.Key_Backspace)
 			return backspace;
 		else if(event["key"] === Qt.Key_Tab || event["text"] === "\t")
@@ -89,7 +89,12 @@ ColumnLayout {
 			return space;
 		if(event["text"] === undefined)
 			return;
-		var keyText = event["text"].toLowerCase();
+		var keyText;
+		var normalized = StringUtils.normalizeString(event["text"]);
+		if(normalizeText && normalized.length > 0)
+			keyText = normalized[0].toLowerCase();
+		else
+			keyText = event["text"].toLowerCase();
 		var ret = getKeyFromRow(keyText, layout.rowB);
 		if(ret !== null)
 			return ret;
@@ -100,19 +105,19 @@ ColumnLayout {
 		if(ret !== null)
 			return ret;
 		ret = getKeyFromRow(keyText, layout.rowE);
+		if(ret === null && !normalizeText)
+			return getKey(event, true);
 		return ret;
 	}
 
 	function highlightKey(event) {
 		var key = getKey(event);
-		console.assert(key !== null);
 		if(key !== null)
 			key.highlighted = true;
 	}
 
 	function dehighlightKey(event) {
 		var key = getKey(event);
-		console.assert(key !== null);
 		if(key !== null)
 			key.highlighted = false;
 	}
@@ -141,14 +146,12 @@ ColumnLayout {
 
 	function pressKey(event) {
 		var key = getKey(event);
-		console.assert(key !== null);
 		if(key !== null)
 			getKey(event).pressed = true;
 	}
 
 	function releaseKey(event) {
 		var key = getKey(event);
-		console.assert(key !== null);
 		if(key !== null)
 			getKey(event).pressed = false;
 	}

--- a/app/ui/qml/KeyboardView.qml
+++ b/app/ui/qml/KeyboardView.qml
@@ -39,7 +39,7 @@ ColumnLayout {
 		for(var i = 0; i < rowRepeater.count; i++)
 		{
 			var item = rowRepeater.itemAt(i);
-			if(item.type === KeyboardUtils.KeyType_Any && item.text === key.text && item.shiftText === key.shiftText)
+			if(item.type === KeyboardUtils.KeyType_Any && item.text === key.displayText && item.shiftText === key.displayShiftText)
 				return item;
 		}
 		return null;
@@ -62,7 +62,8 @@ ColumnLayout {
 	function getKeyFromRow(keyText, rowKeys) {
 		for(var i = 0; i < rowKeys.length; i++)
 		{
-			if(rowKeys[i].text === keyText || rowKeys[i].shiftText === keyText)
+			if(rowKeys[i].text === keyText || rowKeys[i].shiftText === keyText ||
+				rowKeys[i].displayText === keyText || rowKeys[i].displayShiftText === keyText)
 				return findKey(rowKeys[i]);
 		}
 		return null;

--- a/app/ui/qml/KeyboardView.qml
+++ b/app/ui/qml/KeyboardView.qml
@@ -153,6 +153,28 @@ ColumnLayout {
 			getKey(event).pressed = false;
 	}
 
+	function releaseAllKeys() {
+		for(var i = 0; i < rowB.count; i++)
+			rowB.itemAt(i).pressed = false;
+		for(i = 0; i < rowC.count; i++)
+			rowC.itemAt(i).pressed = false;
+		for(i = 0; i < rowD.count; i++)
+			rowD.itemAt(i).pressed = false;
+		for(i = 0; i < rowE.count; i++)
+			rowE.itemAt(i).pressed = false;
+		backspace.pressed = false;
+		tab.pressed = false;
+		capsLock.pressed = false;
+		returnKey.pressed = false;
+		lShift.pressed = false;
+		rShift.pressed = false;
+		lCtrl.pressed = false;
+		lAlt.pressed = false;
+		space.pressed = false;
+		rAlt.pressed = false;
+		rCtrl.pressed = false;
+	}
+
 	KeyboardLayout {
 		property var xkbLayout: ["", ""]
 		id: layout

--- a/app/ui/qml/KeyboardView.qml
+++ b/app/ui/qml/KeyboardView.qml
@@ -79,7 +79,12 @@ ColumnLayout {
 		else if(event["key"] === Qt.Key_Return || event["text"] === "\n")
 			return returnKey;
 		else if(event["key"] === Qt.Key_Shift)
-			return lShift; // TODO: Add support for rShift
+		{
+			if(event["rShift"] === true)
+				return rShift;
+			else
+				return lShift; // TODO: Add support for rShift (pressed key)
+		}
 		else if(event["key"] === Qt.Key_Control)
 			return lCtrl; // TODO: Add support for rCtrl
 		else if(event["key"] === Qt.Key_Alt)

--- a/app/ui/qml/MainWindow.qml
+++ b/app/ui/qml/MainWindow.qml
@@ -808,15 +808,23 @@ ApplicationWindow {
 		if(eventInProgress || blockInput || ((currentMode == 1) && !timedExStarted))
 			return;
 		var keyID = event["key"];
-		keyboard.pressKey(event);
+		var isDeadKey = KeyboardUtils.isDeadKey(keyID);
+		if(!isDeadKey)
+		{
+			if(deadKeys > 0)
+				keyboard.releaseAllKeys()
+			keyboard.pressKey(event);
+		}
 		if(event["isAutoRepeat"])
 			return;
-		if(KeyboardUtils.isDeadKey(keyID))
+		if(isDeadKey)
 		{
 			deadKeys++;
 			// Count modifier key used with the dead key
 			if(event["modifiers"] !== Qt.NoModifier)
 				deadKeys++;
+			event["text"] = KeyboardUtils.deadKeyToString(event["key"]);
+			keyboard.pressKey(event);
 			return;
 		}
 		if(KeyboardUtils.isSpecialKey(event) && (keyID !== Qt.Key_Backspace))
@@ -1171,6 +1179,7 @@ ApplicationWindow {
 		if(fullInput.length < exerciseText.length)
 		{
 			keyboard.dehighlightAllKeys();
+			keyboard.releaseAllKeys();
 			var futureEvent = { "text": displayExercise[displayPos] };
 			// TODO: Get the keys that should be highlighted (shift, dead keys)
 			keyboard.highlightKey(futureEvent);

--- a/app/ui/qml/MainWindow.qml
+++ b/app/ui/qml/MainWindow.qml
@@ -1204,10 +1204,20 @@ ApplicationWindow {
 		if(fullInput.length < exerciseText.length)
 		{
 			keyboard.dehighlightAllKeys();
-			var futureEvent = { "text": displayExercise[displayPos] };
-			// TODO: Get the keys that should be highlighted (shift, dead keys)
-			keyboard.highlightKey(futureEvent);
-			// TODO: Get shift key based on next character
+			var keys = keyboard.layout.characterKeys(displayExercise[displayPos]);
+			for(var i = 0; i < keys.length; i++)
+			{
+				var futureEvent;
+				if(keys[i].type === KeyboardUtils.KeyType_Any)
+					futureEvent = { "text": keys[i].displayText };
+				else if(keys[i].type === KeyboardUtils.KeyType_RShift)
+					futureEvent = { "text": "", "key": Qt.Key_Shift, "rShift": true };
+				else if(keys[i].type === KeyboardUtils.KeyType_LShift)
+					futureEvent = { "text": "", "key": Qt.Key_Shift };
+				else
+					futureEvent = { "text": "\n", "key": Qt.Key_Return };
+				keyboard.highlightKey(futureEvent);
+			}
 		}
 	}
 

--- a/app/ui/qml/MainWindow.qml
+++ b/app/ui/qml/MainWindow.qml
@@ -75,6 +75,7 @@ ApplicationWindow {
 	property bool eventInProgress: false
 	property bool blockNextDeadKey: false
 	property string lastDeadKey
+	property string lastKey
 	property bool testLoaded: false
 	property bool uiLocked: false
 	property string formattedExerciseTime
@@ -855,6 +856,7 @@ ApplicationWindow {
 		}
 		var ignoreBackspace = false;
 		var keyText = event["text"];
+		var rawKeyText = keyText;
 		if((keyText === "'") && (displayExercise[displayPos] === "‘"))
 			keyText = "‘";
 		if((keyText === "‘") && (displayExercise[displayPos] === '\''))
@@ -1013,6 +1015,7 @@ ApplicationWindow {
 			paper.mistake += "_";
 		if(!mistake && correctMistakes)
 			highlightNextKey();
+		lastKey = rawKeyText;
 		if(((displayPos >= displayExercise.length) && correctMistakes) || (currentLine >= lineCount + 1))
 		{
 			if(currentLine >= lineCount + 1)
@@ -1030,6 +1033,11 @@ ApplicationWindow {
 
 	function keyRelease(event) {
 		keyboard.releaseKey(event);
+		if(lastKey !== event["text"])
+		{
+			event["text"] = lastKey;
+			keyboard.releaseKey(event);
+		}
 	}
 
 	function endExercise() {

--- a/libcore/src/Key.cpp
+++ b/libcore/src/Key.cpp
@@ -40,7 +40,6 @@ QString Key::text(void)
 void Key::setText(QString text)
 {
 	m_text = text;
-	updateDisplayText();
 }
 
 /*! The text for this key when pressed with shift. */
@@ -52,7 +51,6 @@ QString Key::shiftText(void)
 void Key::setShiftText(QString text)
 {
 	m_shiftText = text;
-	updateDisplayShiftText();
 }
 
 /*! The type of the key. */
@@ -73,20 +71,18 @@ QString Key::displayText(void)
 	return m_displayText;
 }
 
+void Key::setDisplayText(QString text)
+{
+	m_displayText = text;
+}
+
 /*! The text (for combination with the shift key) visible on the keyboard. */
 QString Key::displayShiftText(void)
 {
 	return m_displayShiftText;
 }
 
-/*! Updates display text. \see displayText() */
-void Key::updateDisplayText(void)
+void Key::setDisplayShiftText(QString text)
 {
-	m_displayText = m_text;
-}
-
-/*! Updates display shift text. \see displayShiftText() */
-void Key::updateDisplayShiftText(void)
-{
-	m_displayShiftText = m_shiftText;
+	m_displayShiftText = text;
 }

--- a/libcore/src/Key.cpp
+++ b/libcore/src/Key.cpp
@@ -86,3 +86,14 @@ void Key::setDisplayShiftText(QString text)
 {
 	m_displayShiftText = text;
 }
+
+/*! True if this is a dead key. */
+bool Key::isDead(void)
+{
+	return m_dead;
+}
+
+void Key::setDead(bool dead)
+{
+	m_dead = dead;
+}

--- a/libcore/src/Key.cpp
+++ b/libcore/src/Key.cpp
@@ -99,3 +99,14 @@ void Key::setDead(bool dead)
 {
 	m_dead = dead;
 }
+
+/*! True if this is a dead key when pressed with shift. */
+bool Key::isShiftDead(void)
+{
+	return m_shiftDead;
+}
+
+void Key::setShiftDead(bool dead)
+{
+	m_shiftDead = dead;
+}

--- a/libcore/src/Key.cpp
+++ b/libcore/src/Key.cpp
@@ -28,7 +28,9 @@ Key::Key() { }
 Key::Key(QString text, QString shiftText)
 {
 	setText(text);
+	setDisplayText(text);
 	setShiftText(shiftText);
+	setDisplayShiftText(shiftText);
 }
 
 /*! The text for this key. */

--- a/libcore/src/KeyboardLayout.cpp
+++ b/libcore/src/KeyboardLayout.cpp
@@ -438,7 +438,7 @@ QPair<QString, QString> KeyboardLayout::keyText(QString id, bool *isDead)
 
 	char *buffer = (char *) malloc(8);
 	memset(buffer, 0, 8);
-	xkb_keysym_t keysym = xkb_keysym_from_name(id.toStdString().c_str(), XKB_KEYSYM_CASE_INSENSITIVE);
+	xkb_keysym_t keysym = xkb_keysym_from_name(id.toStdString().c_str(), (xkb_keysym_flags) 0);
 	int ret = xkb_keysym_to_utf8(keysym, buffer, 8);
 	Q_ASSERT(ret >= 0);
 	QString out = QString::fromUtf8(buffer, ret - 1);

--- a/libcore/src/KeyboardLayout.cpp
+++ b/libcore/src/KeyboardLayout.cpp
@@ -147,6 +147,153 @@ KeyboardLayout::Hand KeyboardLayout::fingerHand(Finger finger)
 		return Hand_Right;
 }
 
+/*!
+ * Returns list of keys that should be used to compose the given character.\n
+ * For example:\n
+ * ó -> o + ´\n
+ * Ď -> LShift + ´ (ˇ) + RShift + d\n
+ * (on Slovak keyboard layout)
+ */
+KeyboardRow KeyboardLayout::characterKeys(QChar character)
+{
+	if(character == ' ')
+		return { Key(" ", " ") };
+	else if(character == '\n')
+	{
+		Key returnKey("\n", "\n");
+		returnKey.setType(KeyboardUtils::KeyType_Return);
+		return { returnKey };
+	}
+	QList<Key> keys;
+	Row row;
+	int id;
+	bool shift, ok;
+	Key k = findKey(character, &row, &id, &shift, &ok);
+	if(ok)
+	{
+		if(shift)
+		{
+			Key shiftKey;
+			shiftKey.setType(getShiftKey(row, id));
+			keys.append(shiftKey);
+		}
+		keys.append(k);
+		if(k.isDead())
+			keys.append(Key(" ", ""));
+	}
+	else
+	{
+		QString normalized = QString(character).normalized(QString::NormalizationForm_D);
+		for(int i = 0; i < normalized.length(); i++)
+		{
+			k = findKey(normalized[i], &row, &id, &shift, &ok);
+			if(ok)
+			{
+				keys.prepend(k);
+				if(shift)
+				{
+					Key shiftKey;
+					shiftKey.setType(getShiftKey(row, id));
+					keys.prepend(shiftKey);
+				}
+			}
+		}
+	}
+	return keys;
+}
+
+/*!
+ * Returns the key with the given character in (from the given row).
+ * \param[out] isShifted True if this key has to be composed using shift.
+ * \param[out] ok True if this key exists.
+ */
+Key KeyboardLayout::findKeyInRow(QChar character, KeyboardRow row, int *id, bool *isShifted, bool *ok)
+{
+	for(int i = 0; i < row.length(); i++)
+	{
+		Key key = row[i];
+		if(id)
+			*id = i;
+		if((key.text() == character) || (key.displayText() == character))
+		{
+			if(ok)
+				*ok = true;
+			if(isShifted)
+				*isShifted = false;
+			return key;
+		}
+		if((key.shiftText() == character) || (key.displayShiftText() == character))
+		{
+			if(ok)
+				*ok = true;
+			if(isShifted)
+				*isShifted = true;
+			return key;
+		}
+	}
+	if(ok)
+		*ok = false;
+	return Key();
+}
+
+/*!
+ * Returns the key with the given character.
+ * \param[out] isShifted True if this key has to be composed using shift.
+ * \param[out] ok True if this key exists.
+ */
+Key KeyboardLayout::findKey(QChar character, Row *row, int *id, bool *isShifted, bool *ok)
+{
+	bool tmpOk = false;
+	Row currentRow;
+	Key key;
+	// B
+	currentRow = Row_B;
+	key = findKeyInRow(character, m_rowB, id, isShifted, &tmpOk);
+	if(tmpOk)
+		goto end;
+	// C
+	currentRow = Row_C;
+	key = findKeyInRow(character, m_rowC, id, isShifted, &tmpOk);
+	if(tmpOk)
+		goto end;
+	// D
+	currentRow = Row_D;
+	key = findKeyInRow(character, m_rowD, id, isShifted, &tmpOk);
+	if(tmpOk)
+		goto end;
+	// E
+	currentRow = Row_E;
+	key = findKeyInRow(character, m_rowE, id, isShifted, &tmpOk);
+	if(tmpOk)
+		goto end;
+	if(ok)
+		*ok = false;
+	return Key();
+
+end:
+	if(ok)
+		*ok = true;
+	if(row)
+	{
+		*row = currentRow;
+		if(id)
+		{
+			if(*row != Row_E)
+				*id = *id + 1;
+		}
+	}
+	return key;
+}
+
+/*! Returns the shift key that should be used with the given key. */
+KeyboardUtils::KeyType KeyboardLayout::getShiftKey(Row row, int id)
+{
+	if(fingerHand(keyFinger(row, id)) == Hand_Left)
+		return KeyboardUtils::KeyType_RShift;
+	else
+		return KeyboardUtils::KeyType_LShift;
+}
+
 /*! Initializes the keyboard layout (reads all keys from xkeyboard-config). */
 void KeyboardLayout::init(void)
 {

--- a/libcore/src/KeyboardLayout.cpp
+++ b/libcore/src/KeyboardLayout.cpp
@@ -247,8 +247,10 @@ void KeyboardLayout::loadLayout(QString rawData, QString variantName)
 								auto shiftText = keyText(keyData[1].toList()[0].toString(), &shiftDead);
 								key.setText(text.first);
 								key.setDisplayText(text.second);
+								key.setDead(dead);
 								key.setShiftText(shiftText.first);
 								key.setDisplayShiftText(shiftText.second);
+								key.setShiftDead(shiftDead);
 								KeyboardUtils::KeyType keyType;
 								QPoint pos = keyPos(keyId, &keyType);
 								key.setType(keyType);

--- a/libcore/src/KeyboardLayout.cpp
+++ b/libcore/src/KeyboardLayout.cpp
@@ -242,8 +242,9 @@ void KeyboardLayout::loadLayout(QString rawData, QString variantName)
 							if(keyData.length() >= 2)
 							{
 								Key key;
-								auto text = keyText(keyData[0].toList()[0].toString());
-								auto shiftText = keyText(keyData[1].toList()[0].toString());
+								bool dead, shiftDead;
+								auto text = keyText(keyData[0].toList()[0].toString(), &dead);
+								auto shiftText = keyText(keyData[1].toList()[0].toString(), &shiftDead);
 								key.setText(text.first);
 								key.setDisplayText(text.second);
 								key.setShiftText(shiftText.first);
@@ -407,7 +408,7 @@ QString KeyboardLayout::nestedData(int *pos, QString data, QString startToken, Q
  * Converts key ID (e. g. "backslash" or "bracketleft") to
  * unicode representation of the key (key text and readable text that should be displayed on the keyboard).
  */
-QPair<QString, QString> KeyboardLayout::keyText(QString id)
+QPair<QString, QString> KeyboardLayout::keyText(QString id, bool *isDead)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	bool dead = id.length() > 5 && id.first(5) == "dead_";
@@ -430,6 +431,8 @@ QPair<QString, QString> KeyboardLayout::keyText(QString id)
 		Q_ASSERT(ok);
 		QString text = KeyboardUtils::deadKeyToString(keyId);
 		QString readable = KeyboardUtils::deadKeyToReadableString(keyId);
+		if(isDead)
+			*isDead = true;
 		return QPair<QString, QString>(text, readable);
 	}
 
@@ -440,6 +443,8 @@ QPair<QString, QString> KeyboardLayout::keyText(QString id)
 	Q_ASSERT(ret >= 0);
 	QString out = QString::fromUtf8(buffer, ret - 1);
 	free(buffer);
+	if(isDead)
+		*isDead = false;
 	return QPair<QString, QString>(out, out);
 }
 

--- a/libcore/src/KeyboardLayout.cpp
+++ b/libcore/src/KeyboardLayout.cpp
@@ -242,8 +242,12 @@ void KeyboardLayout::loadLayout(QString rawData, QString variantName)
 							if(keyData.length() >= 2)
 							{
 								Key key;
-								key.setText(keyText(keyData[0].toList()[0].toString()));
-								key.setShiftText(keyText(keyData[1].toList()[0].toString()));
+								auto text = keyText(keyData[0].toList()[0].toString());
+								auto shiftText = keyText(keyData[1].toList()[0].toString());
+								key.setText(text.first);
+								key.setDisplayText(text.second);
+								key.setShiftText(shiftText.first);
+								key.setDisplayShiftText(shiftText.second);
 								KeyboardUtils::KeyType keyType;
 								QPoint pos = keyPos(keyId, &keyType);
 								key.setType(keyType);
@@ -399,8 +403,11 @@ QString KeyboardLayout::nestedData(int *pos, QString data, QString startToken, Q
 	return out;
 }
 
-/*! Convert key ID (e. g. "backslash" or "bracketleft") to unicode representation of the key. */
-QString KeyboardLayout::keyText(QString id)
+/*!
+ * Converts key ID (e. g. "backslash" or "bracketleft") to
+ * unicode representation of the key (key text and readable text that should be displayed on the keyboard).
+ */
+QPair<QString, QString> KeyboardLayout::keyText(QString id)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	bool dead = id.length() > 5 && id.first(5) == "dead_";
@@ -421,7 +428,9 @@ QString KeyboardLayout::keyText(QString id)
 		if(!ok)
 			qCritical("%s", QString("Unsupported dead key: " + id).toStdString().c_str());
 		Q_ASSERT(ok);
-		return KeyboardUtils::deadKeyToString(keyId);
+		QString text = KeyboardUtils::deadKeyToString(keyId);
+		QString readable = KeyboardUtils::deadKeyToReadableString(keyId);
+		return QPair<QString, QString>(text, readable);
 	}
 
 	char *buffer = (char *) malloc(8);
@@ -431,7 +440,7 @@ QString KeyboardLayout::keyText(QString id)
 	Q_ASSERT(ret >= 0);
 	QString out = QString::fromUtf8(buffer, ret - 1);
 	free(buffer);
-	return out;
+	return QPair<QString, QString>(out, out);
 }
 
 /*!

--- a/libcore/src/KeyboardUtils.cpp
+++ b/libcore/src/KeyboardUtils.cpp
@@ -66,6 +66,82 @@ bool KeyboardUtils::isDeadKey(int key)
 /*! Returns the text for the given dead key. */
 QString KeyboardUtils::deadKeyToString(Qt::Key key)
 {
+	switch(key)
+	{
+		case Qt::Key_Dead_Grave:
+			return QChar(0x0300);
+		case Qt::Key_Dead_Acute:
+			return QChar(0x0301);
+		case Qt::Key_Dead_Circumflex:
+			return QChar(0x0302);
+		case Qt::Key_Dead_Tilde:
+			return QChar(0x0303);
+		case Qt::Key_Dead_Macron:
+			return QChar(0x0304);
+		case Qt::Key_Dead_Breve:
+			return QChar(0x0306);
+		case Qt::Key_Dead_Abovedot:
+			return QChar(0x0307);
+		case Qt::Key_Dead_Diaeresis:
+			return QChar(0x0308);
+		case Qt::Key_Dead_Abovering:
+			return QChar(0x030A);
+		case Qt::Key_Dead_Doubleacute:
+			return QChar(0x030B);
+		case Qt::Key_Dead_Caron:
+			return QChar(0x030C);
+		case Qt::Key_Dead_Cedilla:
+			return QChar(0x0327);
+		case Qt::Key_Dead_Ogonek:
+			return QChar(0x0328);
+		case Qt::Key_Dead_Iota:
+			return QChar(0x0345);
+		case Qt::Key_Dead_Voiced_Sound:
+			return QChar(0x3099);
+		case Qt::Key_Dead_Semivoiced_Sound:
+			return QChar(0x309A);
+		case Qt::Key_Dead_Belowdot:
+			return QChar(0x0323);
+		case Qt::Key_Dead_Hook:
+			return QChar(0x0309);
+		case Qt::Key_Dead_Horn:
+			return QChar(0x031B);
+		case Qt::Key_Dead_Stroke:
+			return QChar(0x0338);
+		case Qt::Key_Dead_Abovecomma:
+			return QChar(0x0313);
+		case Qt::Key_Dead_Abovereversedcomma:
+			return QChar(0x0314);
+		case Qt::Key_Dead_Doublegrave:
+			return QChar(0x030F);
+		case Qt::Key_Dead_Belowring:
+			return QChar(0x0325);
+		case Qt::Key_Dead_Belowmacron:
+			return QChar(0x0331);
+		case Qt::Key_Dead_Belowcircumflex:
+			return QChar(0x032D);
+		case Qt::Key_Dead_Belowtilde:
+			return QChar(0x0330);
+		case Qt::Key_Dead_Belowbreve:
+			return QChar(0x032E);
+		case Qt::Key_Dead_Belowdiaeresis:
+			return QChar(0x0324);
+		case Qt::Key_Dead_Invertedbreve:
+			return QChar(0x0311);
+		case Qt::Key_Dead_Belowcomma:
+			return QChar(0x0326);
+		case Qt::Key_Dead_Currency:
+			return QChar(0x00A4);
+		case Qt::Key_Dead_Greek:
+			return QChar(0x037E);
+		default:
+			return QChar();
+	}
+}
+
+/*! Returns the human readable text for the given dead key. */
+QString KeyboardUtils::deadKeyToReadableString(Qt::Key key)
+{
 	// Source: https://github.com/qt/qtwebengine/blob/9ef040a6bef904cbbf9e39135135333cbbae80b1/src/core/web_event_factory.cpp#L917-L983
 	switch(key)
 	{

--- a/libcore/src/KeyboardUtils.cpp
+++ b/libcore/src/KeyboardUtils.cpp
@@ -162,7 +162,7 @@ QString KeyboardUtils::deadKeyToReadableString(Qt::Key key)
 		case Qt::Key_Dead_Diaeresis:
 			return QChar(0x00A8);
 		case Qt::Key_Dead_Abovering:
-			return QChar(0x02DA);
+			return QChar(0x00B0);
 		case Qt::Key_Dead_Doubleacute:
 			return QChar(0x02DD);
 		case Qt::Key_Dead_Caron:

--- a/libcore/src/StringUtils.cpp
+++ b/libcore/src/StringUtils.cpp
@@ -2,7 +2,7 @@
  * StringUtils.cpp
  * This file is part of Open-Typer
  *
- * Copyright (C) 2021-2022 - adazem009
+ * Copyright (C) 2021-2023 - adazem009
  *
  * Open-Typer is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -635,4 +635,10 @@ QString StringUtils::addMistakes(QString exerciseText, QList<MistakeRecord *> re
 			out += i < exerciseText.count() ? QString(exerciseText[i]) : QString();
 	}
 	return out;
+}
+
+/*! Normalizes the given string. */
+QString StringUtils::normalizeString(QString str)
+{
+	return str.normalized(QString::NormalizationForm_D);
 }

--- a/libcore/src/include/Key.h
+++ b/libcore/src/include/Key.h
@@ -39,6 +39,7 @@ class CORE_LIB_EXPORT Key
 		Q_PROPERTY(QString displayText READ displayText WRITE setDisplayText)
 		Q_PROPERTY(QString displayShiftText READ displayShiftText WRITE setDisplayShiftText)
 		Q_PROPERTY(bool dead READ isDead WRITE setDead)
+		Q_PROPERTY(bool shiftDead READ isShiftDead WRITE setShiftDead)
 	public:
 		explicit Key();
 		Key(QString text, QString shiftText);
@@ -54,6 +55,8 @@ class CORE_LIB_EXPORT Key
 		void setDisplayShiftText(QString text);
 		bool isDead(void);
 		void setDead(bool dead);
+		bool isShiftDead(void);
+		void setShiftDead(bool dead);
 
 	private:
 		QString m_text;
@@ -62,6 +65,7 @@ class CORE_LIB_EXPORT Key
 		QString m_displayText;
 		QString m_displayShiftText;
 		bool m_dead;
+		bool m_shiftDead;
 };
 
 typedef QList<Key> KeyboardRow;

--- a/libcore/src/include/Key.h
+++ b/libcore/src/include/Key.h
@@ -36,8 +36,8 @@ class CORE_LIB_EXPORT Key
 		Q_PROPERTY(QString text READ text WRITE setText)
 		Q_PROPERTY(QString shiftText READ shiftText WRITE setShiftText)
 		Q_PROPERTY(KeyboardUtils::KeyType type READ type WRITE setType)
-		Q_PROPERTY(QString displayText READ displayText)
-		Q_PROPERTY(QString displayShiftText READ displayShiftText)
+		Q_PROPERTY(QString displayText READ displayText WRITE setDisplayText)
+		Q_PROPERTY(QString displayShiftText READ displayShiftText WRITE setDisplayShiftText)
 	public:
 		explicit Key();
 		Key(QString text, QString shiftText);
@@ -48,11 +48,11 @@ class CORE_LIB_EXPORT Key
 		KeyboardUtils::KeyType type(void);
 		void setType(KeyboardUtils::KeyType type);
 		QString displayText(void);
+		void setDisplayText(QString text);
 		QString displayShiftText(void);
+		void setDisplayShiftText(QString text);
 
 	private:
-		void updateDisplayText(void);
-		void updateDisplayShiftText(void);
 		QString m_text;
 		QString m_shiftText;
 		KeyboardUtils::KeyType m_type = KeyboardUtils::KeyType_Any;

--- a/libcore/src/include/Key.h
+++ b/libcore/src/include/Key.h
@@ -38,6 +38,7 @@ class CORE_LIB_EXPORT Key
 		Q_PROPERTY(KeyboardUtils::KeyType type READ type WRITE setType)
 		Q_PROPERTY(QString displayText READ displayText WRITE setDisplayText)
 		Q_PROPERTY(QString displayShiftText READ displayShiftText WRITE setDisplayShiftText)
+		Q_PROPERTY(bool dead READ isDead WRITE setDead)
 	public:
 		explicit Key();
 		Key(QString text, QString shiftText);
@@ -51,6 +52,8 @@ class CORE_LIB_EXPORT Key
 		void setDisplayText(QString text);
 		QString displayShiftText(void);
 		void setDisplayShiftText(QString text);
+		bool isDead(void);
+		void setDead(bool dead);
 
 	private:
 		QString m_text;
@@ -58,6 +61,7 @@ class CORE_LIB_EXPORT Key
 		KeyboardUtils::KeyType m_type = KeyboardUtils::KeyType_Any;
 		QString m_displayText;
 		QString m_displayShiftText;
+		bool m_dead;
 };
 
 typedef QList<Key> KeyboardRow;

--- a/libcore/src/include/KeyboardLayout.h
+++ b/libcore/src/include/KeyboardLayout.h
@@ -95,7 +95,7 @@ class CORE_LIB_EXPORT KeyboardLayout : public QObject
 		void loadLayout(QString rawData, QString variantName);
 		QVariantList parse(QString data);
 		QString nestedData(int *pos, QString data, QString startToken, QString endToken);
-		QPair<QString, QString> keyText(QString id);
+		QPair<QString, QString> keyText(QString id, bool *isDead = nullptr);
 		QPoint keyPos(QString keyId, KeyboardUtils::KeyType *type = nullptr);
 		void addKey(Key key, int x, int y);
 		QString m_layoutId;

--- a/libcore/src/include/KeyboardLayout.h
+++ b/libcore/src/include/KeyboardLayout.h
@@ -89,6 +89,7 @@ class CORE_LIB_EXPORT KeyboardLayout : public QObject
 		KeyboardRow rowE(void);
 		Q_INVOKABLE Finger keyFinger(Row row, int id);
 		Q_INVOKABLE Hand fingerHand(Finger finger);
+		Q_INVOKABLE KeyboardRow characterKeys(QChar character);
 
 	private:
 		void init(void);
@@ -98,6 +99,9 @@ class CORE_LIB_EXPORT KeyboardLayout : public QObject
 		QPair<QString, QString> keyText(QString id, bool *isDead = nullptr);
 		QPoint keyPos(QString keyId, KeyboardUtils::KeyType *type = nullptr);
 		void addKey(Key key, int x, int y);
+		Key findKeyInRow(QChar character, KeyboardRow row, int *id = nullptr, bool *isShifted = nullptr, bool *ok = nullptr);
+		Key findKey(QChar character, Row *row = nullptr, int *id = nullptr, bool *isShifted = nullptr, bool *ok = nullptr);
+		KeyboardUtils::KeyType getShiftKey(Row row, int id);
 		QString m_layoutId;
 		QString m_variant;
 		KeyboardRow m_rowB;

--- a/libcore/src/include/KeyboardLayout.h
+++ b/libcore/src/include/KeyboardLayout.h
@@ -95,7 +95,7 @@ class CORE_LIB_EXPORT KeyboardLayout : public QObject
 		void loadLayout(QString rawData, QString variantName);
 		QVariantList parse(QString data);
 		QString nestedData(int *pos, QString data, QString startToken, QString endToken);
-		QString keyText(QString id);
+		QPair<QString, QString> keyText(QString id);
 		QPoint keyPos(QString keyId, KeyboardUtils::KeyType *type = nullptr);
 		void addKey(Key key, int x, int y);
 		QString m_layoutId;

--- a/libcore/src/include/KeyboardUtils.h
+++ b/libcore/src/include/KeyboardUtils.h
@@ -56,6 +56,7 @@ class CORE_LIB_EXPORT KeyboardUtils : public QObject
 		Q_INVOKABLE static bool isSpecialKey(QVariantMap event);
 		Q_INVOKABLE static bool isDeadKey(int key);
 		Q_INVOKABLE static QString deadKeyToString(Qt::Key key);
+		Q_INVOKABLE static QString deadKeyToReadableString(Qt::Key key);
 };
 
 #endif // KEYBOARDUTILS_H

--- a/libcore/src/include/KeyboardUtils.h
+++ b/libcore/src/include/KeyboardUtils.h
@@ -55,7 +55,7 @@ class CORE_LIB_EXPORT KeyboardUtils : public QObject
 		static bool isSpecialKey(QKeyEvent *event);
 		Q_INVOKABLE static bool isSpecialKey(QVariantMap event);
 		Q_INVOKABLE static bool isDeadKey(int key);
-		static QString deadKeyToString(Qt::Key key);
+		Q_INVOKABLE static QString deadKeyToString(Qt::Key key);
 };
 
 #endif // KEYBOARDUTILS_H

--- a/libcore/src/include/StringUtils.h
+++ b/libcore/src/include/StringUtils.h
@@ -2,7 +2,7 @@
  * StringUtils.h
  * This file is part of Open-Typer
  *
- * Copyright (C) 2021-2022 - adazem009
+ * Copyright (C) 2021-2023 - adazem009
  *
  * Open-Typer is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -52,6 +52,7 @@ class CORE_LIB_EXPORT StringUtils : public QObject
 		Q_INVOKABLE static QList<MistakeRecord *> findMistakes(QString exerciseText, QString input, QVector<CharacterRecord *> recordedCharacters, int *totalHits = nullptr, QStringList *errorWords = nullptr);
 		Q_INVOKABLE static QList<MistakeRecord *> validateExercise(QString exerciseText, QString inputText, QVector<CharacterRecord *> recordedCharacters, int *totalHits, int *mistakeCount, QStringList *errorWords = nullptr, bool timed = false, int timeSecs = 0);
 		Q_INVOKABLE static QString addMistakes(QString exerciseText, QList<MistakeRecord *> recordedMistakes);
+		Q_INVOKABLE static QString normalizeString(QString str);
 
 	private:
 		static int lcsLen(QList<QVariant> source, QList<QVariant> target);


### PR DESCRIPTION
- [x] Show pressed dead keys (this even doesn't work in Open-Typer 4, but it's nice to have in v5).
- [x] Properly show next key (shift for uppercase characters and dead keys for composed characters.