### PR TITLE
Fix #19: Use native virtual key codes (or scan codes) for right shift and control

### DIFF
--- a/app/ui/qml/KeyboardView.qml
+++ b/app/ui/qml/KeyboardView.qml
@@ -104,13 +104,18 @@ ColumnLayout {
 			return returnKey;
 		else if(event["key"] === Qt.Key_Shift)
 		{
-			if(event["rShift"] === true)
+			if(event["rShift"] || KeyboardUtils.isRShift(event["nativeScanCode"], event["nativeVirtualKey"]))
 				return rShift;
 			else
-				return lShift; // TODO: Add support for rShift (pressed key)
+				return lShift;
 		}
 		else if(event["key"] === Qt.Key_Control)
-			return lCtrl; // TODO: Add support for rCtrl
+		{
+			if(KeyboardUtils.isRControl(event["nativeScanCode"], event["nativeVirtualKey"]))
+				return rCtrl;
+			else
+				return lCtrl;
+		}
 		else if(event["key"] === Qt.Key_Alt)
 			return lAlt;
 		else if(event["key"] === Qt.Key_AltGr)

--- a/libcore/src/KeyboardUtils.cpp
+++ b/libcore/src/KeyboardUtils.cpp
@@ -238,3 +238,23 @@ bool KeyboardUtils::isRShift(int nativeScanCode, int nativeVirtualKey)
 	return false;
 #endif
 }
+
+/*!
+ * Returns true if the given native virtual key code or scan code belongs to right control.\n
+ * Pass both values to this function; it'll use native scan code or virtual key depending on the platform.
+ * \since Open-Typer 5.0.1
+ */
+bool KeyboardUtils::isRControl(int nativeScanCode, int nativeVirtualKey)
+{
+	Q_UNUSED(nativeScanCode)
+	Q_UNUSED(nativeVirtualKey)
+#if defined(Q_OS_LINUX)
+	return nativeVirtualKey == 0xFFE4;
+#elif defined(Q_OS_WINDOWS)
+	return nativeScanCode == 0x11D;
+#elif defined(Q_OS_MACOS)
+	return nativeVirtualKey == kVK_RightControl;
+#else
+	return false;
+#endif
+}

--- a/libcore/src/KeyboardUtils.cpp
+++ b/libcore/src/KeyboardUtils.cpp
@@ -19,6 +19,9 @@
  */
 
 #include <QMetaEnum>
+#ifdef Q_OS_MACOS
+#include <Carbon/Carbon.h>
+#endif
 #include "KeyboardUtils.h"
 
 /*!
@@ -214,4 +217,24 @@ QString KeyboardUtils::deadKeyToReadableString(Qt::Key key)
 		default:
 			return QChar();
 	}
+}
+
+/*!
+ * Returns true if the given native virtual key code or scan code belongs to right shift.\n
+ * Pass both values to this function; it'll use native scan code or virtual key depending on the platform.
+ * \since Open-Typer 5.0.1
+ */
+bool KeyboardUtils::isRShift(int nativeScanCode, int nativeVirtualKey)
+{
+	Q_UNUSED(nativeScanCode)
+	Q_UNUSED(nativeVirtualKey)
+#if defined(Q_OS_LINUX)
+	return nativeVirtualKey == 0xFFE2;
+#elif defined(Q_OS_WINDOWS)
+	return nativeScanCode == 0x36;
+#elif defined(Q_OS_MACOS)
+	return nativeVirtualKey == kVK_RightShift;
+#else
+	return false;
+#endif
 }

--- a/libcore/src/KeyboardUtils.h
+++ b/libcore/src/KeyboardUtils.h
@@ -57,6 +57,7 @@ class CORE_LIB_EXPORT KeyboardUtils : public QObject
 		Q_INVOKABLE static bool isDeadKey(int key);
 		Q_INVOKABLE static QString deadKeyToString(Qt::Key key);
 		Q_INVOKABLE static QString deadKeyToReadableString(Qt::Key key);
+		Q_INVOKABLE static bool isRShift(int nativeScanCode, int nativeVirtualKey);
 };
 
 #endif // KEYBOARDUTILS_H

--- a/libcore/src/KeyboardUtils.h
+++ b/libcore/src/KeyboardUtils.h
@@ -58,6 +58,7 @@ class CORE_LIB_EXPORT KeyboardUtils : public QObject
 		Q_INVOKABLE static QString deadKeyToString(Qt::Key key);
 		Q_INVOKABLE static QString deadKeyToReadableString(Qt::Key key);
 		Q_INVOKABLE static bool isRShift(int nativeScanCode, int nativeVirtualKey);
+		Q_INVOKABLE static bool isRControl(int nativeScanCode, int nativeVirtualKey);
 };
 
 #endif // KEYBOARDUTILS_H

--- a/libcore/src/QmlKeyboardHandler.cpp
+++ b/libcore/src/QmlKeyboardHandler.cpp
@@ -2,7 +2,7 @@
  * QmlKeyboardHandler.cpp
  * This file is part of Open-Typer
  *
- * Copyright (C) 2022 - adazem009
+ * Copyright (C) 2022-2023 - adazem009
  *
  * Open-Typer is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -72,5 +72,7 @@ QVariantMap QmlKeyboardHandler::convertEvent(QKeyEvent *event)
 	out["text"] = event->text();
 	out["modifiers"] = (int) event->modifiers();
 	out["isAutoRepeat"] = event->isAutoRepeat();
+	out["nativeScanCode"] = event->nativeScanCode();
+	out["nativeVirtualKey"] = event->nativeVirtualKey();
 	return out;
 }


### PR DESCRIPTION
Resolves #19

- [x] Right shift: Linux/X11
- [x] Right shift: Linux/Wayland
- [x] Right shift: Windows
- [x] Right shift: macOS
- [x] Right control: Linux/X11
- [x] Right control: Linux/Wayland
- [x] Right control: Windows
- [x] Right control: macOS